### PR TITLE
fixed missing `@' of variable cdh5_repopath

### DIFF
--- a/templates/cloudera.repo.erb
+++ b/templates/cloudera.repo.erb
@@ -1,6 +1,6 @@
 [cloudera-cdh<%= @version -%>]
 # Packages for Cloudera's Distribution for Hadoop, Version <%= @version -%>, on <%= @operatingsystem -%> <%= @majdistrelease -%> <%= @architecture %>
 name=Cloudera's Distribution for Hadoop, Version <%= @version %>
-baseurl=https://archive.cloudera.com<%= cdh5_repopath -%>/<%= @version -%>/
-gpgkey =https://archive.cloudera.com<%= cdh5_repopath -%>/RPM-GPG-KEY-cloudera
+baseurl=https://archive.cloudera.com<%= @cdh5_repopath -%>/<%= @version -%>/
+gpgkey =https://archive.cloudera.com<%= @cdh5_repopath -%>/RPM-GPG-KEY-cloudera
 gpgcheck = 1


### PR DESCRIPTION
fixed missing `@' of variable cdh5_repopath in templates/cloudera.repo.erb
